### PR TITLE
Add triton-opt and triton-llvm-opt for Triton

### DIFF
--- a/tests/test_torch_custom_pipeline.py
+++ b/tests/test_torch_custom_pipeline.py
@@ -21,7 +21,7 @@ example_input = torch.randn(4, 4)
 
 
 @pytest.mark.parametrize("ir_type", ["llvm_mlir"])
-def test_custom_pipeline(ir_type):
+def test_torch_custom_pipeline(ir_type):
     payload = {
         "code": pytorch_code,
         "ir_type": ir_type,

--- a/tests/test_torch_mlir_conv2d.py
+++ b/tests/test_torch_mlir_conv2d.py
@@ -4,7 +4,7 @@ import httpx
 API_URL = "http://localhost:8000/generate_ir"
 
 
-def test_simple_conv2d_model():
+def test_torch_mlir_conv2d():
     code = """
 import torch
 import torch.nn as nn

--- a/tests/test_torch_mlir_linear.py
+++ b/tests/test_torch_mlir_linear.py
@@ -4,7 +4,7 @@ import httpx
 API_URL = "http://localhost:8000/generate_ir"
 
 
-def test_simple_linear_relu_model():
+def test_torch_mlir_linear():
     code = """
 import torch
 import torch.nn as nn

--- a/tests/test_torch_mlir_two_models.py
+++ b/tests/test_torch_mlir_two_models.py
@@ -4,7 +4,7 @@ import httpx
 API_URL = "http://localhost:8000/generate_ir"
 
 
-def test_two_models():
+def test_torch_mlir_two_models():
     code = """
 import torch
 import torch.nn as nn

--- a/tests/test_torch_mock_opt.py
+++ b/tests/test_torch_mock_opt.py
@@ -17,7 +17,7 @@ def mock_opt_path():
 
     shutil.rmtree(build_dir)
 
-def test_mock_user_tool(mock_opt_path):
+def test_torch_mock_opt(mock_opt_path):
     code = """
 import torch
 import torch.nn as nn

--- a/tests/test_torch_user_controlled_ir_print.py
+++ b/tests/test_torch_user_controlled_ir_print.py
@@ -4,7 +4,7 @@ import httpx
 API_URL = "http://localhost:8000/generate_ir"
 
 
-def test_user_controlled_ir_print():
+def test_torch_user_controlled_ir_print():
     code = """
 import torch
 import torch.nn as nn

--- a/tests/test_triton_mock_opt.py
+++ b/tests/test_triton_mock_opt.py
@@ -1,0 +1,58 @@
+import os
+import subprocess
+import tempfile
+import shutil
+import pytest
+import httpx
+
+@pytest.fixture(scope="session")
+def mock_opt_path():
+    cpp_src = os.path.abspath("tests/cpp_sources/mock-opt.cpp")
+    build_dir = tempfile.mkdtemp()
+    exe_path = os.path.join(build_dir, "mock-opt")
+
+    subprocess.check_call(["g++", cpp_src, "-o", exe_path])
+
+    yield exe_path
+
+    shutil.rmtree(build_dir)
+
+def test_triton_mock_opt(mock_opt_path):
+    code = """
+import triton
+import triton.language as tl
+import torch
+
+BLOCK_SIZE = tl.constexpr(1024)
+
+@triton.jit
+def add_kernel(X, Y, Z, N):
+    pid = tl.program_id(axis=0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < N
+    x = tl.load(X + offsets, mask=mask)
+    y = tl.load(Y + offsets, mask=mask)
+    z = x + y
+    tl.store(Z + offsets, z, mask=mask)
+
+N = 4096
+x = torch.randn(N, device="cuda", dtype=torch.float32)
+y = torch.randn(N, device="cuda", dtype=torch.float32)
+z = torch.empty_like(x)
+
+grid = lambda meta: (triton.cdiv(N, BLOCK_SIZE),)
+add_kernel[grid](x, y, z, N)
+
+"""
+
+    payload = {
+        "code": code,
+        "ir_type": "triton_gpu_ir",
+        "user_tool": f"{mock_opt_path}",
+        "dump_after_each_opt": False,
+    }
+
+    response = httpx.post("http://localhost:8000/generate_ir", json=payload)
+    assert response.status_code == 200
+    assert "tt.func public @add_kernel" in response.json()["output"]
+    assert "test mock_opt 42" in response.json()["output"]

--- a/tests/test_triton_mock_opt.py
+++ b/tests/test_triton_mock_opt.py
@@ -5,6 +5,13 @@ import shutil
 import pytest
 import httpx
 
+import torch
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="No NVIDIA GPU detected. Skip",
+)
+
 @pytest.fixture(scope="session")
 def mock_opt_path():
     cpp_src = os.path.abspath("tests/cpp_sources/mock-opt.cpp")


### PR DESCRIPTION
Also allow to use opt, llc and custom tools for Triron IRs.

mlir-opt remains disabled for Triton as it seem to be unusable without --allow-unregistered-dialect. Yet a user can call mlir-opt as unspecified custom tool (if anybody reading this commit message disagrees - please don't hesitate and comment on the PR or open an issue).

TODO:
- Triton support is still very raw, need to dump IR not from cache dir. With that fix - merge triton_llvm_ir and llvm_ir IR targets.
- Explore AMD and Intel lowering for Triton.
- opt tool bar starts to get overloaded - explicit listing of tools in MLIR ecosystem supported by the app is good for novices like myself, but for advanced users it should be a command line.

git blame note: I've applied npx prettier --write without preserving intermediate stage, so diff became bigger, then I have anticipated.