### PR TITLE
feat: replace flag prompts with modal

### DIFF
--- a/src/app/SessionContext.js
+++ b/src/app/SessionContext.js
@@ -42,7 +42,6 @@ example_input = torch.randn(4, 4)
           dumpAfterEachOpt: false,
         },
       ],
-      customToolCmd: {},
     },
   ]);
   const [activeSourceId, setActiveSourceId] = useState(1);


### PR DESCRIPTION
## Summary
- replace prompt when adding passes with an Ant Design modal and Input
- use same modal to add custom tools for a consistent UI

## Testing
- `npm test` (fails: Missing script "test")
- `pytest` (fails: ModuleNotFoundError: No module named 'httpx')
- `npm run lint` (prompted for ESLint configuration, unable to proceed)


------
https://chatgpt.com/codex/tasks/task_e_688f624a1ae883228ec7dfee2e59037a